### PR TITLE
add --standard option

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,10 +1,14 @@
 package thriftlint
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/alecthomas/go-thrift/parser"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // Severity of a linter message.
@@ -57,6 +61,10 @@ func (w *Messages) Error(object interface{}, msg string, args ...interface{}) Me
 	return *w
 }
 
+type Standard struct {
+	Linters map[string]interface{} `yaml:"linters"`
+}
+
 // Checks is a convenience wrapper around a slice of Checks.
 type Checks []Check
 
@@ -87,12 +95,41 @@ func (c Checks) Has(prefix string) bool {
 	return false
 }
 
+func (c Checks) ApplyStandard(nameOrFilepath string) (checkers Checks, err error) {
+	if nameOrFilepath == "default" {
+		checkers = c
+		return
+	}
+
+	f, err := os.Open(nameOrFilepath)
+	if err != nil {
+		return
+	}
+	buf := bytes.NewBuffer(nil)
+	io.Copy(buf, f)
+
+	standard := Standard{}
+	if err = yaml.Unmarshal(buf.Bytes(), &standard); err != nil {
+		return
+	}
+
+	checkers = make(Checks, 0)
+	for _, checker := range c {
+		if config, ok := standard.Linters[checker.ID()]; ok {
+			checker.Config(config)
+			checkers = append(checkers, checker)
+		}
+	}
+	return
+}
+
 // Check implementations are used by the linter to check AST nodes.
 type Check interface {
 	// ID of the Check. Must be unique across all checks.
 	//
 	// IDs may be hierarchical, separated by a period. eg. "enum", "enum.values"
 	ID() string
+
 	// Checker returns the checking function.
 	//
 	// The checking function has the signature "func(...) Messages", where "..." is a sequence of
@@ -106,6 +143,9 @@ type Check interface {
 	//
 	// Will match all each struct field, but not union fields.
 	Checker() interface{}
+
+	// Config receives a yaml unmarshalled interface{}
+	Config(interface{}) error
 }
 
 // MakeCheck creates a stateless Check type from an ID and a checker function.
@@ -127,4 +167,8 @@ func (s *statelessCheck) ID() string {
 
 func (s *statelessCheck) Checker() interface{} {
 	return s.checker
+}
+
+func (s *statelessCheck) Config(interface{}) error {
+	return nil
 }

--- a/checks/all.go
+++ b/checks/all.go
@@ -1,0 +1,14 @@
+package checks
+
+import "github.com/UrbanCompass/thriftlint"
+
+var AllCheckers = thriftlint.Checks{
+	CheckIndentation(),
+	CheckNames(nil, nil),
+	CheckOptional(),
+	CheckDefaultValues(),
+	CheckEnumSequence(),
+	CheckMapKeys(),
+	CheckTypeReferences(),
+	CheckStructFieldOrder(),
+}

--- a/checks/annotations.go
+++ b/checks/annotations.go
@@ -54,6 +54,10 @@ func (c *annotationsCheck) Checker() interface{} {
 	return c.checker
 }
 
+func (c *annotationsCheck) Config(interface{}) error {
+	return nil
+}
+
 // annotationsCheck verifies that annotations match basic regular expressions.
 //
 // It does not do any semantic checking.

--- a/cmd/thrift-lint/main.go
+++ b/cmd/thrift-lint/main.go
@@ -17,7 +17,9 @@ var (
 	disableFlag     = kingpin.Flag("disable", "Linters to disable.").PlaceHolder("LINTER").Strings()
 	listFlag        = kingpin.Flag("list", "List linter checks.").Bool()
 	errorFlag       = kingpin.Flag("errors", "Only show errors.").Bool()
-	sourcesArgs     = kingpin.Arg("sources", "Thrift sources to lint.").Required().ExistingFiles()
+	standard        = kingpin.Flag("standard", "The name or path of the coding standard to use").Default("default").String()
+
+	sourcesArgs = kingpin.Arg("sources", "Thrift sources to lint.").Required().ExistingFiles()
 )
 
 func main() {
@@ -25,17 +27,13 @@ func main() {
 
 For details, please refer to https://github.com/UrbanCompass/thriftlint
 `
+
 	kingpin.Parse()
-	checkers := thriftlint.Checks{
-		checks.CheckIndentation(),
-		checks.CheckNames(nil, nil),
-		checks.CheckOptional(),
-		checks.CheckDefaultValues(),
-		checks.CheckEnumSequence(),
-		checks.CheckMapKeys(),
-		checks.CheckTypeReferences(),
-		checks.CheckStructFieldOrder(),
-	}
+
+	fmt.Printf("using standard: %s\n", *standard)
+	checkers, err := checks.AllCheckers.ApplyStandard(*standard)
+	kingpin.FatalIfError(err, "")
+
 	checkers = append(checkers, checks.CheckAnnotations(nil, checkers))
 
 	if *listFlag {


### PR DESCRIPTION
Hi, I'm considering to add a `--standard` flag to make it easier to customize.

(Just because we have many teams which has their own naming style...)

```
thrift-lint <thrift_file> --standard=<standard file>
```

And If you leave the `standard` option blank, it will use default standard as it ever was.

Here is a sample of `standard.yaml`

```yaml
linters:
  indentation:
  naming:
    matches:
      service: upperCamel
      constant: upperSnake
    blacklist:
      - class
      - int
  defaults:
  map:
  enum:
  types:
  field.order:
```

I'm looking forward to your reply~